### PR TITLE
feat(AIIDP-24): Implement Basic HTTP Server for API Gateway

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aykay76/ai-idp/internal/config"
+	"github.com/aykay76/ai-idp/internal/logger"
+	"github.com/aykay76/ai-idp/internal/middleware"
+)
+
+// HealthResponse represents the health check response
+type HealthResponse struct {
+	Status    string    `json:"status"`
+	Timestamp time.Time `json:"timestamp"`
+	Service   string    `json:"service"`
+	Version   string    `json:"version,omitempty"`
+}
+
+func main() {
+	// Load configuration
+	cfg := config.Load()
+
+	// Initialize logger
+	appLogger := logger.New(cfg.Logging.Level, cfg.Logging.Format)
+	appLogger.WithFields(logger.LogFields{
+		logger.FieldComponent: "api-gateway",
+		"port":                cfg.Server.Port,
+	}).Info("Starting API Gateway")
+
+	// Create HTTP server mux
+	mux := http.NewServeMux()
+
+	// Health check endpoint
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		response := HealthResponse{
+			Status:    "healthy",
+			Timestamp: time.Now().UTC(),
+			Service:   "ai-idp-api-gateway",
+			Version:   os.Getenv("VERSION"),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			appLogger.WithFields(logger.LogFields{
+				logger.FieldError: err.Error(),
+			}).Error("Failed to encode health response")
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		appLogger.WithFields(logger.LogFields{
+			logger.FieldHTTPMethod: r.Method,
+			logger.FieldHTTPPath:   r.URL.Path,
+			logger.FieldHTTPStatus: http.StatusOK,
+		}).Debug("Health check requested")
+	})
+
+	// Readiness check endpoint (for Kubernetes)
+	mux.HandleFunc("GET /readiness", func(w http.ResponseWriter, r *http.Request) {
+		response := HealthResponse{
+			Status:    "ready",
+			Timestamp: time.Now().UTC(),
+			Service:   "ai-idp-api-gateway",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			appLogger.WithFields(logger.LogFields{
+				logger.FieldError: err.Error(),
+			}).Error("Failed to encode readiness response")
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		appLogger.WithFields(logger.LogFields{
+			logger.FieldHTTPMethod: r.Method,
+			logger.FieldHTTPPath:   r.URL.Path,
+			logger.FieldHTTPStatus: http.StatusOK,
+		}).Debug("Readiness check requested")
+	})
+
+	// Liveness check endpoint (for Kubernetes)
+	mux.HandleFunc("GET /liveness", func(w http.ResponseWriter, r *http.Request) {
+		response := HealthResponse{
+			Status:    "alive",
+			Timestamp: time.Now().UTC(),
+			Service:   "ai-idp-api-gateway",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			appLogger.WithFields(logger.LogFields{
+				logger.FieldError: err.Error(),
+			}).Error("Failed to encode liveness response")
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		appLogger.WithFields(logger.LogFields{
+			logger.FieldHTTPMethod: r.Method,
+			logger.FieldHTTPPath:   r.URL.Path,
+			logger.FieldHTTPStatus: http.StatusOK,
+		}).Debug("Liveness check requested")
+	})
+
+	// Apply middleware chain
+	handler := middleware.RequestID(mux)
+	handler = middleware.Logging(appLogger)(handler)
+
+	// Create HTTP server
+	server := &http.Server{
+		Addr:         ":" + cfg.Server.Port,
+		Handler:      handler,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	// Start server in a goroutine
+	go func() {
+		appLogger.WithFields(logger.LogFields{
+			logger.FieldComponent: "api-gateway",
+			"address":             server.Addr,
+		}).Info("API Gateway server starting")
+
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			appLogger.WithFields(logger.LogFields{
+				logger.FieldComponent: "api-gateway",
+				logger.FieldError:     err.Error(),
+			}).Error("Server failed to start")
+			os.Exit(1)
+		}
+	}()
+
+	appLogger.WithFields(logger.LogFields{
+		logger.FieldComponent: "api-gateway",
+		"port":                cfg.Server.Port,
+	}).Info("API Gateway server started successfully")
+
+	// Wait for interrupt signal to gracefully shutdown the server
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	appLogger.WithFields(logger.LogFields{
+		logger.FieldComponent: "api-gateway",
+	}).Info("API Gateway server shutting down")
+
+	// Create a context with timeout for shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Server.ShutdownTimeout)
+	defer cancel()
+
+	// Attempt graceful shutdown
+	if err := server.Shutdown(ctx); err != nil {
+		appLogger.WithFields(logger.LogFields{
+			logger.FieldComponent: "api-gateway",
+			logger.FieldError:     err.Error(),
+		}).Error("Server forced to shutdown")
+		os.Exit(1)
+	}
+
+	appLogger.WithFields(logger.LogFields{
+		logger.FieldComponent: "api-gateway",
+	}).Info("API Gateway server stopped")
+}


### PR DESCRIPTION
## Summary

This PR implements task AIIDP-24 by creating a basic HTTP server for the API Gateway using Go's native HTTP libraries instead of Gin, as requested.

## Changes

### 🆕 New Features
- **Basic HTTP Server**: Implemented using Go's native `net/http` package (no third-party dependencies)
- **Health Check Endpoints**: 
  - `GET /health` - Basic health status with service info and version
  - `GET /readiness` - Kubernetes readiness probe endpoint
  - `GET /liveness` - Kubernetes liveness probe endpoint
- **Graceful Shutdown**: Proper shutdown handling with SIGINT/SIGTERM signals and configurable timeout
- **Middleware Integration**: Uses existing RequestID and Logging middleware

### 🔧 Technical Details
- **Configuration-driven**: Uses existing config system for port, host, and shutdown timeout
- **Structured Logging**: Leverages internal logger package with observability fields
- **Error Handling**: Proper error handling with structured logging
- **Timeouts**: Configured read, write, and idle timeouts for production use
- **JSON Responses**: All endpoints return proper JSON responses with timestamps

### 🧪 Testing
- ✅ All health endpoints tested and working
- ✅ Graceful shutdown verified
- ✅ Structured logging confirmed
- ✅ Request middleware functioning
- ✅ Build process successful

### 📋 Task Completion
- [x] Create basic HTTP server setup
- [x] Implement health check endpoint (/health) 
- [x] Add readiness and liveness endpoints for Kubernetes
- [x] Implement proper shutdown handling
- [x] Use Go native libraries (no Gin dependency)
- [x] Single main.go file in cmd/api-gateway
- [x] Integrate with existing middleware and logging systems

## Related Issues
Resolves: AIIDP-24

## Testing Instructions
```bash
# Build the application
go build -o bin/api-gateway ./cmd/api-gateway

# Start the server
PORT=8081 ./bin/api-gateway

# Test endpoints
curl http://localhost:8081/health
curl http://localhost:8081/readiness  
curl http://localhost:8081/liveness
```

## Deployment Notes
- Server respects PORT environment variable (defaults to config)
- All endpoints return JSON with proper Content-Type headers
- Graceful shutdown timeout is configurable via config system
- Ready for Kubernetes deployment with health probes